### PR TITLE
Fixed weird formatting bug in web page

### DIFF
--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -64,8 +64,9 @@
                     <span class="mdc-button__ripple">Pictures</span>
                 </button>
             </div>
-	    <div id="icons">
-              <ul> 
+        </div>
+        <div id="icons">
+            <ul> 
                 <li> 
                     <a href="https://github.com/mmurray22" target="_blank">
                         <img class="icon" src="/images/logo-github.svg" alt="Github icon">
@@ -81,8 +82,7 @@
                         <img class="icon" src="/images/email-24px.svg" alt="Email Icon">
                     </a>
                 </li>
-              </ul>
-            </div>
+            </ul>
         </div>
     </div>
     <div id="inner-content">

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -170,7 +170,6 @@ ul {
 
 #intro-button-one {
   display: inline-block;
-  padding: 1%;
 }
 
 #intro-button-two {


### PR DESCRIPTION
Before this fix, all the buttons on the right side of the profile where not inline-block with the centerpiece profile and the other buttons on the left side of the profile. After this fix, all the buttons are in the right place.

Here is the website before the fix:
![image](https://user-images.githubusercontent.com/36782608/87366340-51839700-c52d-11ea-8c46-0661c616a39e.png)


Here is the website after the fix:
![image](https://user-images.githubusercontent.com/36782608/87366463-97d8f600-c52d-11ea-8fd4-33ab89b1ea2e.png)